### PR TITLE
Add ignore rules for build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,17 @@
+# LaTeX build artifacts
+*.aux
+*.log
+*.toc
+*.lof
+*.lot
+*.fls
+*.out
+*.bbl
+*.blg
+*.lol
+*.fdb_latexmk
+*.synctex.gz
+
+# Python artifacts
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
## Summary
- ignore common LaTeX build artifacts
- ignore Python bytecode

## Testing
- `pytest -q`