### PR TITLE
Remove placeholder exclude patterns from Jupyter Book config

### DIFF
--- a/jupyterbook/_config.yml
+++ b/jupyterbook/_config.yml
@@ -7,8 +7,6 @@ copyright: "2025"
 # See https://jupyterbook.org/content/execute.html
 execute:
   execute_notebooks: auto
-  exclude_patterns:
-    - 'pattern_to_exclude'
   timeout: 100
   allow_errors: false
 


### PR DESCRIPTION
## Summary
- remove placeholder `execute.exclude_patterns` from Jupyter Book configuration

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688f5668e1d88327a457f6e52b0376cf